### PR TITLE
Fixing API link in plugins view

### DIFF
--- a/assets/js/app/plugins/plugins.html
+++ b/assets/js/app/plugins/plugins.html
@@ -44,7 +44,7 @@
                 </td>
                 <th>{{item.name}}</th>
                 <td>
-                    <a data-ng-if="item.api_id" data-ui-sref="apis.edit({id:item.api_id})">{{item.api_id}}</a>
+                    <a data-ng-if="item.api_id" data-ui-sref="apis.edit({api_id:item.api_id})">{{item.api_id}}</a>
                     <span data-ng-if="!item.api_id" >All APIs</span>
                 </td>
                 <td>


### PR DESCRIPTION
On plugins view, when a specific api plugin is displayed, the link is not valid because expected parameter is 'api_id', not 'id'