### PR TITLE
Making the search in the API dashboard apply globally across all pages.

### DIFF
--- a/assets/js/app/apis/apis.html
+++ b/assets/js/app/apis/apis.html
@@ -37,7 +37,7 @@
                     <th width="1"></th>
                 </tr>
                 <tr
-                        dir-paginate="api in apis.data | orderBy:'created_at':true | itemsPerPage: 25 | filter : search">
+                        dir-paginate="api in apis.data | orderBy:'created_at':true | filter : search | itemsPerPage: 25">
                     <td>
 
                         <i


### PR DESCRIPTION
Hi,

This is a PR to make the search in the API dashboard apply globally across all the APIs.
Currently, the search applies only to the current page elements. 