### PR TITLE
Fix snapshot upload

### DIFF
--- a/assets/js/app/settings/snapshots/snapshots-controller.js
+++ b/assets/js/app/settings/snapshots/snapshots-controller.js
@@ -257,7 +257,7 @@
                     var importedSnapshot;
 
                     try{
-                        importedSnapshot = JSON.parse($base64.decode($scope.file.data.replace("data:;base64,","")))
+                        importedSnapshot = JSON.parse($base64.decode($scope.file.data.split(",")[1]))
                     }catch(err){
                         MessageService.error(err)
                     }


### PR DESCRIPTION
Snapshot upload could fail when the base64 prefix was containing the file
format.

i.e: data:application/json;base64

Instead of replacing a specific string, split the string on the comma and take
the second part.