### PR TITLE
Update dashboard charts for more visibility

### DIFF
--- a/assets/js/app/dashboard/02_dashboard-controller.js
+++ b/assets/js/app/dashboard/02_dashboard-controller.js
@@ -49,11 +49,7 @@
                   server : {
                       labels : [
                           'Accepted',
-                          'Active',
                           'Handled',
-                          'Reading',
-                          'Waiting',
-                          'Writing',
                           'Total Requests'
                       ],
                       options: {
@@ -64,19 +60,53 @@
                                       maxRotation: 0,
                                       minRotation: 0
                                   }
+                              }],
+                              yAxes: [{
+                                  ticks: {
+                                      min: 0
+                                  }
                               }]
                           }
                       },
                       series : ['Connections'],
                       data : [
                           $scope.status.server.connections_accepted,
-                          $scope.status.server.connections_active,
                           $scope.status.server.connections_handled,
+                          $scope.status.server.total_requests
+                      ]
+                  },
+                  activity : {
+                      labels : [
+                          'Active',
+                          'Reading',
+                          'Waiting',
+                          'Writing',
+                      ],
+                      options: {
+                          scales: {
+                              xAxes: [{
+                                  ticks: {
+                                      autoSkip: false,
+                                      maxRotation: 0,
+                                      minRotation: 0
+                                  }
+                              }],
+                              yAxes: [{
+                                  ticks: {
+                                      min: 0
+                                  }
+                              }]
+                          }
+                      },
+                      series : ['Connections'],
+                      data : [
+                          $scope.status.server.connections_active,
                           $scope.status.server.connections_reading,
                           $scope.status.server.connections_waiting,
-                          $scope.status.server.connections_writing,
-                          $scope.status.server.total_requests,
+                          $scope.status.server.connections_writing
                       ]
+
+
                   },
                   timers : {
                       labels : [
@@ -84,10 +114,11 @@
                           'Running'
                       ],
                       options : {
-                          //title: {
-                          //    display: true,
-                          //    text: 'timers'
-                          //},
+                          yAxes: [{
+                            ticks: {
+                              min: 0
+                          }
+                        }]
                       },
                       series : ['Timers'],
                       data : [

--- a/assets/js/app/dashboard/dashboard.html
+++ b/assets/js/app/dashboard/dashboard.html
@@ -32,18 +32,17 @@
 
 <div data-ng-if="!loading && !error && info">
     <div class="row" vertilize-container>
-        <!-- CONNECTIONS -->
-        <div class="col-md-8">
+        <!-- REQUESTS -->
+        <div class="col-md-4">
             <div class="panel panel-default" vertilize>
                 <div class="panel-heading">
                     <div class="panel-title">
                         <i class="mdi mdi-cast-connected"></i>&nbsp;
-                        CONNECTIONS
+                        REQUESTS
                     </div>
                 </div>
                 <div class="panel-body">
                     <canvas id="server"
-                            height="75"
                             class="chart chart-bar"
                             chart-data="data.server.data"
                             chart-labels="data.server.labels"
@@ -53,8 +52,28 @@
                 </div>
             </div>
         </div>
+        <!-- END REQUESTS -->
+        <!-- CONNECTIONS -->
+        <div class="col-md-4">
+            <div class="panel panel-default" vertilize>
+                <div class="panel-heading">
+                    <div class="panel-title">
+                        <i class="mdi mdi-cast-connected"></i>&nbsp;
+                        CONNECTIONS
+                    </div>
+                </div>
+                <div class="panel-body">
+                    <canvas id="activity"
+                            class="chart chart-bar"
+                            chart-data="data.activity.data"
+                            chart-labels="data.activity.labels"
+                            chart-options="data.activity.options"
+                            chart-series="data.activity.series">
+                    </canvas>
+                </div>
+            </div>
+        </div>
         <!-- END CONNECTIONS -->
-
         <!-- TIMERS -->
         <div class="col-md-4">
             <div class="panel panel-default" vertilize>


### PR DESCRIPTION


The connections data gets obscured in the requests chart soon after Kong starts because the requests is cummulative and the connections are a current status count.  This change simply splits the data into two charts so you can see the connection status.

![screen shot 2017-09-19 at 10 33 54](https://user-images.githubusercontent.com/393782/30585872-10a6e8b8-9d26-11e7-9a50-b37f1dec6002.png)