### PR TITLE
Add environment variables for socket adapter configuration 

### DIFF
--- a/config/sockets.js
+++ b/config/sockets.js
@@ -35,8 +35,18 @@ module.exports.sockets = {
    * via port 6379                                                            *
    *                                                                          *
    ***************************************************************************/
-  adapter: 'memory',
-
+  
+  /**
+   * Server Socket adapter
+   *
+   * Default: memory
+   * Options: `socket.io-redis` or `memory`
+   */
+  adapter: process.env.SOCKET_ADAPTER || 'memory',
+  host: process.env.REDIS_HOST || 'localhost',
+  port: process.env.REDIS_PORT || 6379,
+  db: process.env.REDIS_DB || 'konga',
+  pass: process.env.REDIS_PASS || null,
   //
   // -OR-
   //

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "sails-mysql": "^0.11.5",
     "sails-postgresql": "^0.11.4",
     "sails-sqlserver": "^0.10.8",
+    "socket.io-redis": "~1.0.0",
     "sendmail": "^1.1.1",
     "ua-parser": "0.3.5",
     "unirest": "^0.5.1",


### PR DESCRIPTION
[resolves #137] This is a minor PR which exposes environment variables for socket adapter configuration to allow easy socket config in docker.

Sails allows one of two adapter options `socket.io-redis` or `memory`. I'm not sure if you want to wrap this to allow a more intuitive `redis` option or just leave it the way sails wants it. I tested this in docker and it seems to work fine.

