### PR TITLE
Adding back PostgreSQL connection pool size configuration

### DIFF
--- a/config/connections.js
+++ b/config/connections.js
@@ -78,7 +78,7 @@ module.exports.connections = {
     password: process.env.DB_PASSWORD || 'admin1!',
     port: process.env.DB_PORT || 5432,
     database: process.env.DB_DATABASE ||'konga_database',
-    //poolSize: process.env.DB_POOLSIZE || 10,
+    poolSize: process.env.DB_POOLSIZE || 10,
     ssl: process.env.DB_SSL ? true : false // If set, assume it's true
   },
 


### PR DESCRIPTION
Since this commit the possibility to configure Sails PostgreSQL connection pool size have been ignored. https://github.com/pantsel/konga/commit/add6f7f6a819ee3f1520661f79943d6a3f3cfa57#diff-5b6a3e5c4b7b6a1c371e0536de7397e2L79
Since that was changes related to adding SQL Server it looks like a misstake.

This change makes it possible to configure pool size again.