### PR TITLE
Fix timeouts to match kong defaults

### DIFF
--- a/assets/js/app/apis/apis-service.js
+++ b/assets/js/app/apis/apis-service.js
@@ -34,9 +34,9 @@
                         strip_uri: true,
                         preserve_host: false,
                         retries: 5,
-                        upstream_connect_timeout: 6000,
-                        upstream_send_timeout: 6000,
-                        upstream_read_timeout: 6000,
+                        upstream_connect_timeout: 60000,
+                        upstream_send_timeout: 60000,
+                        upstream_read_timeout: 60000,
                         https_only: false,
                         http_if_terminated: true,
                         upstream_url: ''


### PR DESCRIPTION
The default timeouts for new apis are 60000 in kong and 6000 in konga.    The help text also says 60000.  