### PR TITLE
Fix GET targets AND Add possibility to select Hash_on for Upstreams for Kong 0.12.X

### DIFF
--- a/assets/js/app/upstreams/add-upstream-modal.html
+++ b/assets/js/app/upstreams/add-upstream-modal.html
@@ -62,7 +62,7 @@
                   <br><em>
                       <small class="help-block">optional</small>
                   </em></label>
-              <div class="col-sm-8">
+              <div class="col-sm-7">
                   <input ng-model="upstream.hash_on" class="form-control">
                   <div class="text-danger" ng-if="errors.hash_on" data-ng-bind="errors.hash_on"></div>
                   <p class="help-block">

--- a/assets/js/app/upstreams/add-upstream-modal.html
+++ b/assets/js/app/upstreams/add-upstream-modal.html
@@ -57,6 +57,19 @@
 
             </div>
         </div>
+		 <div class="form-group" ng-class="{'has-error' : errors.hash_on}">
+              <label class="col-sm-4 control-label">Hash on
+                  <br><em>
+                      <small class="help-block">optional</small>
+                  </em></label>
+              <div class="col-sm-8">
+                  <input ng-model="upstream.hash_on" class="form-control">
+                  <div class="text-danger" ng-if="errors.hash_on" data-ng-bind="errors.hash_on"></div>
+                  <p class="help-block">
+                       What to use as hashing input: <code>none</code>, <code>consumer</code>, <code>ip</code>, or <code>header</code> (defaults to <code>none</code> resulting in a weighted-round-robin scheme).
+                  </p>
+             </div>
+         </div>
         <div class="form-group">
             <div class="col-sm-offset-4 col-sm-7">
                 <button type="submit" class="btn btn-primary btn-block" ng-click="submit()">

--- a/assets/js/app/upstreams/edit-details.html
+++ b/assets/js/app/upstreams/edit-details.html
@@ -63,6 +63,20 @@
 
                 </div>
             </div>
+			 <div class="form-group" ng-class="{'has-error' : errors.hash_on}">
+                <label class="col-sm-3 control-label">Hash on
+                    <br><em>
+                        <small class="help-block">optional</small>
+                    </em></label>
+                <div class="col-sm-8">
+                    <input ng-model="upstream.hash_on" class="form-control">
+                    <div class="text-danger" ng-if="errors.hash_on" data-ng-bind="errors.hash_on"></div>
+                    <p class="help-block">
+                       What to use as hashing input: <code>none</code>, <code>consumer</code>, <code>ip</code>, or <code>header</code> (defaults to <code>none</code> resulting in a weighted-round-robin scheme).
+                    </p>
+
+                </div>
+            </div>
             <div class="form-group">
                 <div class="col-sm-offset-3 col-sm-8">
                     <button type="submit" class="btn btn-primary" ng-click="submit()">

--- a/assets/js/app/upstreams/targets/edit-upstream-targets-controller.js
+++ b/assets/js/app/upstreams/targets/edit-upstream-targets-controller.js
@@ -14,7 +14,7 @@
                           $log, $state,Upstream, MessageService, $uibModal, DataModel, ListConfig, $http, DialogService ) {
 
 
-          var Target = new DataModel('kong/upstreams/' + $stateParams.id + '/targets/active',true)
+          var Target = new DataModel('kong/upstreams/' + $stateParams.id + '/targets',true)
           Target.setScope($scope, false, 'items', 'itemCount');
 
 


### PR DESCRIPTION
Fix get All targets (https://getkong.org/docs/0.12.x/admin-api/#list-targets), the endpoint has been modified since Kong 0.11.X

Upstreams has been upgraded since 0.12.X, this little fix allow to set the "hash_on" attribute for an upstream (https://getkong.org/docs/0.12.x/admin-api/#upstream-objects)