### PR TITLE
Fix error when creating new upstream

### DIFF
--- a/assets/js/app/upstreams/add-upstream-modal-controller.js
+++ b/assets/js/app/upstreams/add-upstream-modal-controller.js
@@ -35,8 +35,8 @@
           // Fix non numeric arrays
           var arr = ["active.healthy", "active.unhealthy", "passive.healthy", "passive.unhealthy"];
           arr.forEach(function (item) {
-            if (_.get(upstream, 'healthchecks.' + item + '.http_statuses')) {
-              _.update(upstream, 'healthchecks.' + item + '.http_statuses', function (statuses) {
+            if (_.get($scope.upstream, 'healthchecks.' + item + '.http_statuses')) {
+              _.update($scope.upstream, 'healthchecks.' + item + '.http_statuses', function (statuses) {
                 return _.map(statuses, function (status) {
                   try{
                     return parseInt(status);


### PR DESCRIPTION
When trying to add a new upstream, the error is thrown on the console:
![screenshot from 2018-06-13 15 43 07](https://user-images.githubusercontent.com/14558910/41371989-6b6ab648-6f22-11e8-954f-b9e7fc617a5c.png)

I noticed that the `upstream` var was a property of `$scope` that was missing.