### PR TITLE
Plugin status viewable by read only users

### DIFF
--- a/assets/js/app/plugins/plugins.html
+++ b/assets/js/app/plugins/plugins.html
@@ -58,11 +58,13 @@
                     </td>
                     <td>
 
-                        <i class="mdi mdi-toggle-switch text-success clickable"
+                        <i class="mdi mdi-toggle-switch text-success"
+                           ng-class="{'clickable': user.hasPermission($state.name.split('.')[0],'update')}"
                            ng-show="item.enabled"
                            ng-click="user.hasPermission($state.name.split('.')[0],'update') && togglePlugin(item)"
                            uib-tooltip="Enabled"></i>
-                        <i class="mdi mdi-toggle-switch-off text-muted clickable"
+                        <i class="mdi mdi-toggle-switch-off text-muted"
+                           ng-class="{'clickable': user.hasPermission($state.name.split('.')[0],'update')}"
                            ng-show="!item.enabled"
                            ng-click="user.hasPermission($state.name.split('.')[0],'update') && togglePlugin(item)"
                            uib-tooltip="Disabled"></i>

--- a/assets/js/app/plugins/plugins.html
+++ b/assets/js/app/plugins/plugins.html
@@ -28,7 +28,7 @@
             <table class="table table-hover table-striped">
                 <tr>
                     <th width="1"></th>
-                    <th width="1" ng-if="user.hasPermission($state.name.split('.')[0],'update')"></th>
+                    <th width="1"></th>
                     <th width="1"></th>
                     <th width="{{item.width}}" class="text-nowrap"
                         data-ng-repeat="item in titleItems | filter:titleFilter"
@@ -56,15 +56,15 @@
                     <td>
                         <img ng-src="images/kong/plugins/{{item.name}}.png" style="height: 42px">
                     </td>
-                    <td ng-if="user.hasPermission($state.name.split('.')[0],'update')">
+                    <td>
 
                         <i class="mdi mdi-toggle-switch text-success clickable"
                            ng-show="item.enabled"
-                           ng-click="togglePlugin(item)"
+                           ng-click="user.hasPermission($state.name.split('.')[0],'update') && togglePlugin(item)"
                            uib-tooltip="Enabled"></i>
                         <i class="mdi mdi-toggle-switch-off text-muted clickable"
                            ng-show="!item.enabled"
-                           ng-click="togglePlugin(item)"
+                           ng-click="user.hasPermission($state.name.split('.')[0],'update') && togglePlugin(item)"
                            uib-tooltip="Disabled"></i>
                     </td>
                     <td>

--- a/assets/js/app/routes/views/route-plugins.html
+++ b/assets/js/app/routes/views/route-plugins.html
@@ -40,11 +40,13 @@
             <img ng-src="images/kong/plugins/{{item.name}}.png" style="height: 42px">
         </td>
         <td>
-            <i class="mdi mdi-toggle-switch text-success clickable"
+            <i class="mdi mdi-toggle-switch text-success"
+               ng-class="{'clickable': user.hasPermission('plugins','edit')}"
                ng-show="item.enabled"
                ng-click="user.hasPermission('plugins','edit') && togglePlugin(item)"
                uib-tooltip="Enabled"></i>
-            <i class="mdi mdi-toggle-switch-off text-muted clickable"
+            <i class="mdi mdi-toggle-switch-off text-muted"
+               ng-class="{'clickable': user.hasPermission('plugins','edit')}"
                ng-show="!item.enabled"
                ng-click="user.hasPermission('plugins','edit') && togglePlugin(item)"
                uib-tooltip="Disabled"></i>

--- a/assets/js/app/routes/views/route-plugins.html
+++ b/assets/js/app/routes/views/route-plugins.html
@@ -27,7 +27,7 @@
 <table class="table" ng-if="plugins">
     <tr>
         <th width="1"></th>
-        <th width="1" ng-if="user.hasPermission('plugins','edit')"></th>
+        <th width="1"></th>
         <th width="1"></th>
         <th>Name</th>
         <th>Consumer</th>
@@ -39,14 +39,14 @@
         <td>
             <img ng-src="images/kong/plugins/{{item.name}}.png" style="height: 42px">
         </td>
-        <td ng-if="user.hasPermission('plugins','edit')">
+        <td>
             <i class="mdi mdi-toggle-switch text-success clickable"
                ng-show="item.enabled"
-               ng-click="togglePlugin(item)"
+               ng-click="user.hasPermission('plugins','edit') && togglePlugin(item)"
                uib-tooltip="Enabled"></i>
             <i class="mdi mdi-toggle-switch-off text-muted clickable"
                ng-show="!item.enabled"
-               ng-click="togglePlugin(item)"
+               ng-click="user.hasPermission('plugins','edit') && togglePlugin(item)"
                uib-tooltip="Disabled"></i>
         </td>
         <td>

--- a/assets/js/app/services/views/service-plugins.html
+++ b/assets/js/app/services/views/service-plugins.html
@@ -28,7 +28,7 @@
 <table class="table" ng-if="!loading">
     <tr>
         <th width="1"></th>
-        <th width="1" ng-if="canEdit"></th>
+        <th width="1"></th>
         <th width="1"></th>
         <th>Name</th>
         <th>Consumer</th>

--- a/assets/js/app/services/views/service-plugins.html
+++ b/assets/js/app/services/views/service-plugins.html
@@ -41,11 +41,13 @@
             <img ng-src="images/kong/plugins/{{item.name}}.png" style="height: 42px">
         </td>
         <td>
-            <i class="mdi mdi-toggle-switch text-success clickable"
+            <i class="mdi mdi-toggle-switch text-success"
+               ng-class="{'clickable': canEdit}"
                ng-show="item.enabled"
                ng-click="canEdit && togglePlugin(item)"
                uib-tooltip="Enabled"></i>
-            <i class="mdi mdi-toggle-switch-off text-muted clickable"
+            <i class="mdi mdi-toggle-switch-off text-muted"
+               ng-class="{'clickable': canEdit}"
                ng-show="!item.enabled"
                ng-click="canEdit && togglePlugin(item)"
                uib-tooltip="Disabled"></i>

--- a/assets/js/app/services/views/service-plugins.html
+++ b/assets/js/app/services/views/service-plugins.html
@@ -40,14 +40,14 @@
         <td>
             <img ng-src="images/kong/plugins/{{item.name}}.png" style="height: 42px">
         </td>
-        <td ng-if="canEdit">
+        <td>
             <i class="mdi mdi-toggle-switch text-success clickable"
                ng-show="item.enabled"
-               ng-click="togglePlugin(item)"
+               ng-click="canEdit && togglePlugin(item)"
                uib-tooltip="Enabled"></i>
             <i class="mdi mdi-toggle-switch-off text-muted clickable"
                ng-show="!item.enabled"
-               ng-click="togglePlugin(item)"
+               ng-click="canEdit && togglePlugin(item)"
                uib-tooltip="Disabled"></i>
         </td>
         <td>


### PR DESCRIPTION
I would find this useful, don't know about others.

This would allow a user without edit access to given resources the ability to see whether a plugin is enabled at-a-glance from the plugin views. The toggle functionality remains disabled.

I didn't see any specific contribution guidelines, apologies if I missed them, I am happy to close and reopen if necessary.