### PR TITLE
reduce limit to work with 1.0.x

### DIFF
--- a/assets/js/app/core/services/ListConfigService.js
+++ b/assets/js/app/core/services/ListConfigService.js
@@ -603,7 +603,7 @@
             return {
               itemCount: 0,
               items: [],
-              itemsFetchSize: 4294967295,
+              itemsFetchSize: 1000,
               itemsPerPage: 25,
               titleItems: this.getTitleItems(property),
               itemsPerPageOptions: [10, 25, 50, 100],

--- a/assets/js/app/routes/00_routes.js
+++ b/assets/js/app/routes/00_routes.js
@@ -31,7 +31,7 @@
                   _services: [
                     'ServiceModel', function resolve(ServiceModel) {
                       return ServiceModel.load({
-                        size : 4294967295
+                        size : 1000
                       })
                     }
                   ]


### PR DESCRIPTION
Kong 1.0.2 errors for services, routes, and upstreams with an error that the size must be between 1 and 1000. Reduced the size to 1000 for getting objects to make it work with 1.0.2 