### PR TITLE
Fix unescaped database name when creating database

### DIFF
--- a/makedb/dbs/mysql.js
+++ b/makedb/dbs/mysql.js
@@ -48,7 +48,7 @@ module.exports = {
 
         console.log("Creating database `" + ( parsedOpts ? parsedOpts.database : dbConf.connections.mysql.database ) + "` if not exists.");
 
-        connection.query('CREATE DATABASE IF NOT EXISTS ' + ( parsedOpts ? parsedOpts.database : dbConf.connections.mysql.database ), function (error, results, fields) {
+        connection.query('CREATE DATABASE IF NOT EXISTS `' + ( parsedOpts ? parsedOpts.database : dbConf.connections.mysql.database ' + '`'), function (error, results, fields) {
             if (error) {
                 console.error(error);
                 return next(error);

--- a/makedb/dbs/pg.js
+++ b/makedb/dbs/pg.js
@@ -119,7 +119,7 @@ module.exports = {
                 return next(err);
             }
 
-            client.query('CREATE DATABASE ' + opts.database, function (err, res) {
+            client.query('CREATE DATABASE `' + opts.database + '`', function (err, res) {
                 if (err) {
                     console.log("Failed to create `" + opts.database +"`",err);
                     done();


### PR DESCRIPTION
### Bug description

Database name is not escaped when creating database.

### How to reproduce

Environment variables
```
NODE_ENV=development
DB_ADAPTER=mysql
DB_HOST=<host>
DB_PORT=<port>
DB_USER=<user>
DB_PASSWORD=<password>
DB_DATABASE=<string>-konga
```

Commands
```bash
npm start

> kongadmin@0.14.2 start /<project_path>/konga
> node --harmony app.js

{ Error: ER_PARSE_ERROR: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '-konga' at line 1
...
```