### PR TITLE
Bug fixes to configmap.yaml

### DIFF
--- a/charts/konga/templates/configmap.yaml
+++ b/charts/konga/templates/configmap.yaml
@@ -9,27 +9,27 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
   {{- if .Values.config }}
-  PORT: {{ default 1337 .Values.config.port }}
+  PORT: "{{ default 1337 .Values.config.port }}"
   NODE_ENV: {{ default "development" .Values.config.node_env }}
   SSL_KEY_PATH: {{ .Values.config.ssl_key_path }}
   SSL_CRT_PATH: {{ .Values.config.ssl_crt_path }}
-  KONGA_HOOK_TIMEOUT: {{ default "60000" .Values.config.konga_hook_timeout }}
+  KONGA_HOOK_TIMEOUT: "{{ default 60000 .Values.config.konga_hook_timeout }}"
   DB_ADAPTER: {{ default "postgres" .Values.config.db_adapter }}
   DB_URI: {{ .Values.config.db_uri }}
   DB_HOST: {{ default "localhost" .Values.config.db_host }}
-  DB_PORT: {{ default "5432" .Values.config.db_port }}
+  DB_PORT: "{{ default 5432 .Values.config.db_port }}"
   DB_USER: {{ .Values.config.db_user }}
   DB_PASSWORD: {{ .Values.config.db_password }}
   DB_DATABASE: {{ default "konga_database" .Values.config.db_database }}
   DB_PG_SCHEMA: {{ default "public" .Values.config.db_pg_schema }}
   {{- if eq .Values.config.node_env "development" }}
-    KONGA_LOG_LEVEL: {{ default "debug" .Values.config.log_level }}
+  KONGA_LOG_LEVEL: {{ default "debug" .Values.config.log_level }}
   {{ else if eq .Values.config.node_env "production" }}
-    KONGA_LOG_LEVEL: {{ default "warn" .Values.config.log_level }}
+  KONGA_LOG_LEVEL: {{ default "warn" .Values.config.log_level }}
   {{- end }}
   TOKEN_SECRET: {{ .Values.config.token_secret }}
   {{- end }}
-  
+
   {{- if .Values.ldap }}
   KONGA_AUTH_PROVIDER: {{ default "local" .Values.ldap.auth_provider }}
   KONGA_LDAP_HOST: {{ default "ldap://localhost:389" .Values.ldap.host }}


### PR DESCRIPTION
Two template updates to allow user-provided configuration to render properly.

1) integer values were not quoted when provided through Values.config.*
2) `KONGA_LOG_LEVEL` indentation was causing template rendering to fail.