### PR TITLE
Bugfix: config and ldap default values were set to lists

### DIFF
--- a/charts/konga/values.yaml
+++ b/charts/konga/values.yaml
@@ -18,25 +18,25 @@ service:
 
 
 # Konga default configuration
-config: []
+config: {}
 #   port: 1337
 #   node_env: development
 #   ssl_key_path:
 #   ssl_crt_path:
 #   konga_hook_timeout: 60000
 #   db_adapter: postgres
-#   db_uri: 
+#   db_uri:
 #   db_host: localhost
 #   db_port: 5432
-#   db_user: 
-#   db_password: 
+#   db_user:
+#   db_password:
 #   db_database: konga_database
 #   db_pg_schema: public
 #   log_level: debug
-#   token_secret: 
+#   token_secret:
 
 # LDAP configuration for Konga
-ldap: []
+ldap: {}
 # ldap:
 #   auth_provider:
 #   host:


### PR DESCRIPTION
Bugfix: config and ldap default values were set to lists when they are dictionaries. Causes Helm to issue warning when user sets values.

If user sets values in either, then helm will log:
- Warning: Building values map for chart 'konga'. Skipped value (map[]) for 'config', as it is not a table.
