### PR TITLE
For empty lists, use null instead of empty string

### DIFF
--- a/assets/js/app/plugins/edit-plugin-controller.js
+++ b/assets/js/app/plugins/edit-plugin-controller.js
@@ -177,8 +177,12 @@
               } else {
                 var path = prefix ? prefix + "." + key : key;
                 if (fields[key].value instanceof Array && _plugin.name !== 'statsd') {
-                  // Transform to comma separated string
-                  data['config.' + path] = fields[key].value.join(",");
+                  if (fields[key].value.length === 0) {
+                    data['config.' + path] = null;
+                  } else {
+                    // Transform to comma separated string
+                    data['config.' + path] = fields[key].value.join(",");
+                  }
                 } else {
                   data['config.' + path] = fields[key].value;
                 }


### PR DESCRIPTION
When updating a plugin configuration, if the element is an array
and the update is to remove all elements from that list,
Konga was sending an empty string to represent the empty list.

When using the CORS plugin, the plugin code checks for the list to be
null, but not always for an empty list.

This patch makes Konga send a null instead of an empty string
when updating a plugin list to become an empty list.

**Note**: we are currently running Konga 0.13.0 because we have yet to migrate to Kong 1.0 (we have plugins that need to be updated first).  That is why I made this change on the legacy branch.  If you think this change is safe and you want it on master, just let me know and I can make another PR.