### PR TITLE
Add ENV HOST support for sails `host` to bind host by IP address.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ These are the general environment variables Konga uses.
 
 | VAR                | DESCRIPTION                                                                                                                | VALUES                                 | DEFAULT                                      |
 |--------------------|----------------------------------------------------------------------------------------------------------------------------|----------------------------------------|----------------------------------------------|
+| HOST               | The IP address that will be bind by Konga's server                                                                               | -                                      | '0.0.0.0'                                         |
 | PORT               | The port that will be used by Konga's server                                                                               | -                                      | 1337                                         |
 | NODE_ENV           | The environment                                                                                                            | `production`,`development`             | `development`                                |
 | SSL_KEY_PATH       | If you want to use SSL, this will be the absolute path to the .key file. Both `SSL_KEY_PATH` & `SSL_CRT_PATH` must be set. | -                                      | null                                         |

--- a/assets/js/app/routes/partials/form-route-013.html
+++ b/assets/js/app/routes/partials/form-route-013.html
@@ -50,6 +50,18 @@
         </p>
     </div>
 </div>
+<div class="form-group" ng-class="{'has-error' : errors.https_redirect_status_code}">
+        <label class="col-sm-3 control-label">Https redirect status code <br><em><small class="help-block">optional</small></em></label>
+        <div class="col-sm-9">
+            <input type="number" class="form-control" ng-model="route.https_redirect_status_code">
+            <p class="help-block">
+                The status code Kong responds with when all properties of a Route match except the protocol,
+                i.e. if the protocol of the request is <code>HTTP</code> instead of <code>HTTPS</code>.
+                <code>Location</code> header is injected by Kong if the field is set to 301, 302, 307 or 308. 
+                Defaults to <code>426</code>.
+            </p>
+        </div>
+</div>
 <div class="form-group" ng-class="{'has-error' : errors.regex_priority}">
     <label class="col-sm-3 control-label">Regex priority <br><em><small class="help-block">optional</small></em></label>
     <div class="col-sm-9">

--- a/assets/js/app/routes/routes-service.js
+++ b/assets/js/app/routes/routes-service.js
@@ -26,6 +26,7 @@
             paths: [],
             strip_path: true,
             preserve_host: false,
+            https_redirect_status_code: 426,
             regex_priority: 0
           }
         }

--- a/bin/konga.js
+++ b/bin/konga.js
@@ -16,6 +16,7 @@ if (argv._[0] === 'help') {
 else if (argv._[0] === 'play')
 {
     var port = process.env.PORT || argv.port
+    var host = process.env.HOST || argv.host
 
     console.log("------------------------------------------------------")
     console.log("Playing Konga!")
@@ -26,6 +27,7 @@ else if (argv._[0] === 'play')
 
     var args = ["app.js","--prod"]
     if(port) args.push("--port=" + port)
+    if(host) args.push("--host=" + host)
 
     console.log(args)
 
@@ -82,7 +84,6 @@ else if(argv._[0] === 'prepare') {
 
     });
   });
-
 
 }
 else

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -23,6 +23,8 @@ module.exports = {
 
   port: process.env.PORT || 1337,
 
+  host: process.env.HOST || "0.0.0.0",
+
   // kong_admin_url: process.env.KONG_ADMIN_URL || 'http://127.0.0.1:8001',
 
   ssl: {

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -33,6 +33,8 @@ module.exports = {
 
   port: process.env.PORT || 1337,
 
+  host: process.env.HOST || "0.0.0.0",
+
   ssl: {
     key: process.env.SSL_KEY_PATH ? fs.readFileSync(process.env.SSL_KEY_PATH) : null,
     cert: process.env.SSL_CRT_PATH ? fs.readFileSync(process.env.SSL_CRT_PATH) : null


### PR DESCRIPTION
Add support `ENV HOST` to bind host with IP address. Instead of `0.0.0.0` only.