### PR TITLE
Changed Dockerfile so that the application doesn't run as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,12 +13,11 @@ RUN apk upgrade --update \
         /app/.git \
         /app/screenshots \
         /app/test \
+    && adduser -H -S -g "Konga service owner" -D -u 1200 -s /sbin/nologin konga \
     && mkdir /app/kongadata \
-    && chown -R 1000:1000 /app
+    && chown -R 1200:1200 /app/views /app/kongadata
 
 EXPOSE 1337
-
-USER 1000:1000
 
 VOLUME /app/kongadata
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ RUN apk upgrade --update \
         /app/screenshots \
         /app/test \
     && adduser -H -S -g "Konga service owner" -D -u 1200 -s /sbin/nologin konga \
-    && mkdir /app/kongadata \
-    && chown -R 1200:1200 /app/views /app/kongadata
+    && mkdir /app/kongadata /app/.tmp \
+    && chown -R 1200:1200 /app/views /app/kongadata /app/.tmp
 
 EXPOSE 1337
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,13 @@ RUN apk upgrade --update \
     && rm -rf /var/cache/apk/* \
         /app/.git \
         /app/screenshots \
-        /app/test
+        /app/test \
+    && mkdir /app/kongadata \
+    && chown -R 1000:1000 /app
 
 EXPOSE 1337
+
+USER 1000:1000
 
 VOLUME /app/kongadata
 


### PR DESCRIPTION
Ideally Konga should not run as root inside the container. This change makes it so that Konga runs with the uid/guid of the node user.

The change has only been lightly tested.