### PR TITLE
feat(consumers): list view includes hyperlink for custom_id

### DIFF
--- a/assets/js/app/consumers/index.html
+++ b/assets/js/app/consumers/index.html
@@ -51,7 +51,7 @@
                         <raw-view data-item="consumer"></raw-view>
                     </td>
                     <td><a data-ui-sref="consumers.edit({'id':consumer.id})"><strong>{{consumer.username || "-"}}</strong></a></td>
-                    <td>{{consumer.custom_id || "-"}}</td>
+                    <td><a data-ui-sref="consumers.edit({'id':consumer.id})"><strong>{{consumer.custom_id || "-"}}</strong></a></td>
                     <td>
                         <span class="badge badge-tag badge-success badge-inverse" ng-repeat="tag in consumer.tags">
                             <i class="mdi mdi-tag"></i>&nbsp;


### PR DESCRIPTION
[resubmitted on different upstream branch as requested (using :next)]

Kong consumers have a semi optional field, `username` and `custom_id`. In our use case we have opted for the latter.  Unfortunately this means for us that the clickable link is a a tiny `-` character; we can't click on the custom ID:

![screenshot](https://cdn-std.droplr.net/files/acc_595791/3ycxkI)

This PR makes both the custom ID _and_ the username fields clickable, allowing for both use cases.