### PR TITLE
Fix issue 443 plugin proxy_cache got "expected an integer"

### DIFF
--- a/assets/js/app/plugins/plugin-helper-service.js
+++ b/assets/js/app/plugins/plugin-helper-service.js
@@ -53,6 +53,12 @@
                             //     }
                             // }
 
+                            if (fields[key].value instanceof Array
+                                && fields[key].elements.type === "integer") {
+                                fields[key].value = fields[key].value.map(function(value) {
+                                    return parseInt(value);
+                                });
+                            }
 
                             if(!data.config) data.config = {};
 


### PR DESCRIPTION
This MR fix the problem from https://github.com/pantsel/konga/issues/433 when trying to add the proxy_cache plugin to a route, service or globally.

It just transforms the string elements of the array generated by `chips` with integers when the field elements type is integer.

Steps to test:

1. Go to `Plugins`
2. Add a new `Global Plugin` and use `Others` > `Proxy Cache`
3. Write some response codes `200` `304`...
4. Select `strategy` > `memory`
5. Save.

Hope it helps