### PR TITLE
konga node data and user data (via configmaps and mounts)

### DIFF
--- a/charts/konga/templates/configmap.yaml
+++ b/charts/konga/templates/configmap.yaml
@@ -28,6 +28,8 @@ data:
   KONGA_LOG_LEVEL: {{ default "warn" .Values.config.log_level }}
   {{- end }}
   TOKEN_SECRET: {{ .Values.config.token_secret }}
+  KONGA_SEED_KONG_NODE_DATA_SOURCE_FILE: "{{ .Values.config.konga_node_data }}"
+  KONGA_SEED_USER_DATA_SOURCE_FILE: "{{ .Values.config.konga_user_data }}"
   {{- end }}
 
   {{- if .Values.ldap }}

--- a/charts/konga/templates/deployment.yaml
+++ b/charts/konga/templates/deployment.yaml
@@ -19,6 +19,10 @@ spec:
         app.kubernetes.io/name: {{ include "konga.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      volumes:
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 8 }}
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -40,6 +44,10 @@ spec:
                 name: {{ include "konga.fullname" . }}-config
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | nindent 12 }}
+{{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/konga/values.yaml
+++ b/charts/konga/values.yaml
@@ -34,6 +34,8 @@ config: {}
 #   db_pg_schema: public
 #   log_level: debug
 #   token_secret:
+#   konga_node_data:
+#   konga_user_data:
 
 # LDAP configuration for Konga
 ldap: {}


### PR DESCRIPTION
This PR allows using KONGA_SEED_KONG_NODE_DATA_SOURCE_FILE and KONGA_SEED_USER_DATA_SOURCE_FILE with the Helm Chart to seed an admin user and a kong admin endpoint by mounting such files with a configmap.

The configmap should provide content for `konga_node.data` and `konga_user.data` like in the example below (please notice that kong_admin_url is an "in-cluster" url):

```
data:
  konga_node.data: |-
    module.exports = [
        {
            "name": "kong-admin",
            "type": "key_auth",
            "kong_admin_url": "http://your-kong-admin:8444",
            "health_checks": false,
        }
    ]

  konga_user.data: |-
    module.exports = [
        {
            "username": "admin",
            "email": "admin@somewhere.com",
            "admin": true,
            "active" : true,
            "password": "somepassword"
        }
    ]
```