### PR TITLE
Use new plugins schema endpoint

### DIFF
--- a/assets/js/app/plugins/plugins-service.js
+++ b/assets/js/app/plugins/plugins-service.js
@@ -33,7 +33,7 @@
           },
 
           schema: function (name) {
-            return $http.get('kong/plugins/schema/' + name);
+            return $http.get('kong/schemas/plugins/' + name);
           },
 
           enabled: function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3300,7 +3300,8 @@
     "hoek": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+      "optional": true
     },
     "hooker": {
       "version": "0.2.3",
@@ -6051,7 +6052,8 @@
           "dependencies": {
             "lodash": {
               "version": "4.17.10",
-              "resolved": ""
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+              "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
             }
           }
         },


### PR DESCRIPTION
The current plugin schema endpoint is deprecated. This PR changes the URL to match the new endpoint.

I've opened this as a draft, since I'm not experienced with Angular and couldn't find a way to make it backwards-compatible for versions of Kong <1.2.0.

Closes #529 