### PR TITLE
On first succesfull login against LDAP, created user.id is not propagated

### DIFF
--- a/api/services/protocols/ldap.js
+++ b/api/services/protocols/ldap.js
@@ -38,7 +38,7 @@ var ldapToUser = function (ldapUser, user, next) {
                 console.error("Failed to create user from ldap", err);
                 next(err);
             } else {
-                next(null, data);
+                next(null, user);
             }
         });
     }


### PR DESCRIPTION
On first succesfull login against LDAP, created user.id is not propagated to next(), hence login fails although user is successfully created in Konga's datastore