### PR TITLE
Allow database prepare command to use environment variables.

### DIFF
--- a/bin/konga.js
+++ b/bin/konga.js
@@ -54,13 +54,9 @@ else if(argv._[0] === 'prepare') {
     return process.exit(1);
   }
 
-  if(!process.env.DB_URI && !argv.uri) {
-    Sails.log.error("No db connection string is defined. Set --uri {db_connection_string}")
-    return process.exit(1);
-  }
-
   process.env.DB_ADAPTER = process.env.DB_ADAPTER || argv.adapter;
-  process.env.DB_URI = process.env.DB_URI || argv.uri;
+  if(argv.uri)
+    process.env.DB_URI = argv.uri
   process.env.PORT = _.isString(argv.port) || _.isNumber(argv.port) ? argv.port : 1339;
 
   require("../makedb")(function(err) {

--- a/start.sh
+++ b/start.sh
@@ -12,8 +12,8 @@ if [ $# -eq 0 ]
         case "${option}"
             in
             c) COMMAND=${OPTARG};;
-            a) ADAPTER=${OPTARG};;
-            u) URI=${OPTARG};;
+            a) ADAPTER_OPTS="--adapter ${OPTARG}";;
+            u) URI_OPTS="--uri ${OPTARG}";;
         esac
     done
 
@@ -24,7 +24,7 @@ if [ $# -eq 0 ]
 
     if [ "$COMMAND" == "prepare" ]
         then
-            node ./bin/konga.js $COMMAND --adapter $ADAPTER --uri $URI
+            node ./bin/konga.js $COMMAND $ADAPTER_OPTS $URI_OPTS
         else
             echo "Invalid command: $COMMAND"
             exit


### PR DESCRIPTION
The files `/makedb/dbs/pg.js`, `makedb/dbs/mysql.js` and `/config/connections.js` allow the user to pass the standard database connection environment variables into the prepare command so long as a connection URL is not set.  However, if `-u <url>` is not passed into `start.sh`, then the `kong.js` invocation becomes `./bin/kong.js prepare --adapter postgres --uri`. The argument parser then interprets this as `argv.uri=true` and the process tries to connect with connection URL "true". The changes in `start.sh` attempt to address this.

Moving on to `kong.js`, we omit setting `process.env.DB_URI` at all if `argv.uri` is empty. This prevents `process.env.DB_URI` from becoming string "undefined" and causing the same problem as string "true".

Finally, this PR removes the validation requiring a connection URL. I believe this is currently ignored if ran via `startup.sh` as `argv.uri` was either true or a nonempty string.