### PR TITLE
Node activate/deactivate issue fix

### DIFF
--- a/api/policies/dynamicNode.js
+++ b/api/policies/dynamicNode.js
@@ -11,11 +11,11 @@ var _ = require('lodash');
  */
 module.exports = function dynamicNode(request, response, next) {
 
-  if (request.headers['connection-id'] || request.query.connection_id) {
+  if (request.query.connection_id || request.headers['connection-id']) {
 
-    sails.log.debug("Policy:dynamicNode", "`connection-id` is defined.", request.headers['connection-id'] || request.query.connection_id);
+    sails.log.debug("Policy:dynamicNode", "`connection-id` is defined.", request.query.connection_id || request.headers['connection-id']);
 
-    sails.models.kongnode.findOne(request.headers['connection-id'] || request.query.connection_id)
+    sails.models.kongnode.findOne(request.query.connection_id || request.headers['connection-id'])
       .exec(function (err, node) {
         if (err) return next(err);
         if (!node) return response.notFound({


### PR DESCRIPTION
In some cases in local storage information about node may be outdated, and in this case connection_id sent in request has lower priority. It causes issue when operation is performed on wrong node connection (that may even not exist in DB).
This pull requests makes higher priority for connection_id sent as GET-argument, than from connection_id from header.