### PR TITLE
helm values support configMap 

### DIFF
--- a/charts/konga/templates/configmap.yaml
+++ b/charts/konga/templates/configmap.yaml
@@ -49,3 +49,7 @@ data:
   KONGA_LDAP_ATTR_LASTNAME: {{ default "sn" .Values.ldap.attr_lastname }}
   KONGA_LDAP_ATTR_EMAIL: {{ default "mail" .Values.ldap.attr_email }}
   {{- end }}
+  
+  {{- range $k, $v := .Values.configMap }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}


### PR DESCRIPTION
The current template some optional ENV are required in`.Values.config`
e.g.
```yaml
port: 1337
node_env: production
ssl_key_path: ""
ssl_crt_path: ""
konga_hook_timeout: 60000
db_adapter: postgres
db_uri: ""
db_host: postgresql-1609690598.default
db_port: 5432
db_user: postgres
db_password: passwordhere
db_database: konga_database
db_pg_schema: public
log_level: info
token_secret: ""
konga_node_data: ""
konga_user_data: ""
```
will tell that ssl_key_path, ssl_crt_path and db_uri are not valid in ConfigMap.data since it's `nill`

why we have to enter `db_uri` since other `db_*` already suppied and vice versa