### PR TITLE
Get rid of sensitive information into logs

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -28,8 +28,6 @@ module.exports = _.merge(_.cloneDeep(require('../base/Controller')), {
 
     update : function(req,res) {
 
-        sails.log(req.body)
-
         var user = req.body;
         var passports = req.body.passports
 

--- a/api/models/KongNode.js
+++ b/api/models/KongNode.js
@@ -99,8 +99,6 @@ var defaultModel = _.merge(_.cloneDeep(require('../base/Model')), {
 
   afterDestroy: function (values, cb) {
 
-    sails.log("KongNode:afterDestroy:called => ", values);
-
     // Stop health checks
     values.forEach(function (node) {
       HealthCheckEvents.emit('health_checks.stop', node);

--- a/api/models/Passport.js
+++ b/api/models/Passport.js
@@ -131,8 +131,6 @@ var defaultModel = {
    */
   beforeUpdate: function beforeUpdate(passport, next) {
 
-      sails.log("########################################",passport)
-
     if (passport.hasOwnProperty('password')) {
 
       bcrypt.hash(passport.password, 10, function callback(error, hash) {

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -70,9 +70,6 @@ var defaultModel = _.merge(_.cloneDeep(require('../base/Model')), {
 
   afterDestroy: function (values, cb) {
 
-    sails.log("User:afterDestroy:called => ", values);
-
-
     var fns = [];
 
     values.forEach(function (user) {

--- a/api/services/protocols/local.js
+++ b/api/services/protocols/local.js
@@ -87,7 +87,7 @@ exports.login = function login(request, identifier, password, next) {
       } else if (!user) {
         next(null, false);
       } else {
-        sails.log("Passport:Policy:local:findUser =>",user)
+        sails.log("Passport:Policy:local:findUser:error =>",error)
         sails.models.passport
           .findOne({
             protocol: 'local',
@@ -95,7 +95,6 @@ exports.login = function login(request, identifier, password, next) {
           })
           .exec(function onExec(error, passport) {
             sails.log("Passport:Policy:local:findUserPassport:error =>",error)
-            sails.log("Passport:Policy:local:findUserPassport =>",passport)
             if (passport) {
               passport.validatePassword(password, function callback(error, response) {
                 if (error) {


### PR DESCRIPTION
Currently on local login it shows all user information including apikey for Kong and user passport for Konga also it show user passport and KongNode information when they were changed