### PR TITLE
Konga 01 fix consumer accessible routes behavior

### DIFF
--- a/assets/js/app/consumers/routes/consumer-routes-controller.js
+++ b/assets/js/app/consumers/routes/consumer-routes-controller.js
@@ -50,7 +50,7 @@
         function getGeneralPlugins(api) {
 
           return _.filter(api.plugins.data,function(item){
-            return !item.consumer_id;
+            return !item.consumer;
           });
         }
 
@@ -58,7 +58,7 @@
         function getConsumerPlugins(api) {
 
           return _.filter(api.plugins.data,function(item){
-            return item.consumer_id && item.consumer_id === $stateParams.id;
+            return item.consumer && item.consumer_id === $stateParams.id;
           });
         }
 

--- a/assets/js/app/consumers/services/consumer-services-controller.js
+++ b/assets/js/app/consumers/services/consumer-services-controller.js
@@ -48,7 +48,7 @@
         function getGeneralPlugins(api) {
 
           return _.filter(api.plugins,function(item){
-            return !item.consumer_id;
+            return !item.consumer;
           });
         }
 
@@ -56,7 +56,7 @@
         function getConsumerPlugins(api) {
 
           return _.filter(api.plugins,function(item){
-            return item.consumer_id && item.consumer_id === $stateParams.id;
+            return item.consumer && item.consumer.id === $stateParams.id;
           });
         }
 


### PR DESCRIPTION
Related to #678 

Fixed code to show properly Consumer -> Accesible routes -> Plugins behavior. Now plugin should be shown related to the user that has active an specific plugin.