### PR TITLE
Fix helm chart by making some parameters as optional

### DIFF
--- a/charts/konga/Chart.yaml
+++ b/charts/konga/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "1.1"
 description: A Helm chart for Kubernetes
 name: konga
 version: 1.0.0

--- a/charts/konga/Chart.yaml
+++ b/charts/konga/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.1"
+appVersion: "0.14.9"
 description: A Helm chart for Kubernetes
 name: konga
-version: 1.0.0
+version: 1.0.1

--- a/charts/konga/templates/configmap.yaml
+++ b/charts/konga/templates/configmap.yaml
@@ -11,15 +11,22 @@ data:
   {{- if .Values.config }}
   PORT: "{{ default 1337 .Values.config.port }}"
   NODE_ENV: {{ default "development" .Values.config.node_env }}
+  {{- if .Values.config.ssl_key_path }}
   SSL_KEY_PATH: {{ .Values.config.ssl_key_path }}
+  {{- end }}
+  {{- if .Values.config.ssl_crt_path }}
   SSL_CRT_PATH: {{ .Values.config.ssl_crt_path }}
+  {{- end }}
   KONGA_HOOK_TIMEOUT: "{{ default 60000 .Values.config.konga_hook_timeout }}"
   DB_ADAPTER: {{ default "postgres" .Values.config.db_adapter }}
+  {{- if .Values.config.db_uri }}
   DB_URI: {{ .Values.config.db_uri }}
+  {{- else }}
   DB_HOST: {{ default "localhost" .Values.config.db_host }}
   DB_PORT: "{{ default 5432 .Values.config.db_port }}"
   DB_USER: {{ .Values.config.db_user }}
   DB_PASSWORD: {{ .Values.config.db_password }}
+  {{- end }}
   DB_DATABASE: {{ default "konga_database" .Values.config.db_database }}
   DB_PG_SCHEMA: {{ default "public" .Values.config.db_pg_schema }}
   {{- if eq .Values.config.node_env "development" }}
@@ -27,7 +34,9 @@ data:
   {{ else if eq .Values.config.node_env "production" }}
   KONGA_LOG_LEVEL: {{ default "warn" .Values.config.log_level }}
   {{- end }}
+  {{- if .Values.config.token_secret }}
   TOKEN_SECRET: {{ .Values.config.token_secret }}
+  {{- end }}
   KONGA_SEED_KONG_NODE_DATA_SOURCE_FILE: "{{ .Values.config.konga_node_data }}"
   KONGA_SEED_USER_DATA_SOURCE_FILE: "{{ .Values.config.konga_user_data }}"
   {{- end }}


### PR DESCRIPTION
Fixing issue with helm chart by defining `token_secret`, `ssl_crt_path`, `ssl_key_path` as optional. Also, if `db_uri` is defined then `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD` will not be created.

Here is the output with the same `values.yaml` file as described in #713:

```
NAME: konga
LAST DEPLOYED: Sat Aug 14 09:58:53 2021
NAMESPACE: kong
STATUS: deployed
REVISION: 1
NOTES:
1. Get the application URL by running these commands:
  export NODE_PORT=$(kubectl get --namespace kong -o jsonpath="{.spec.ports[0].nodePort}" services konga)
  export NODE_IP=$(kubectl get nodes --namespace kong -o jsonpath="{.items[0].status.addresses[0].address}")
  echo http://$NODE_IP:$NODE_PORT
```

Closes #713 