### PR TITLE
Added ENV['DB_IS_PG12_OR_NEWER'] to support Postgres12 or newer versions

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -5,3 +5,4 @@ DB_ADAPTER=postgres
 DB_URI=postgresql://localhost:5432/konga
 KONGA_LOG_LEVEL=warn
 TOKEN_SECRET=some_secret_token
+DB_IS_PG12_OR_NEWER=true

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ These are the general environment variables Konga uses.
 | DB_PASSWORD        | If `DB_URI` is not specified, this is the database user's password. Depends on `DB_ADAPTER`.                               | -                                      | -                                            |
 | DB_DATABASE        | If `DB_URI` is not specified, this is the name of Konga's db.  Depends on `DB_ADAPTER`.                                    | -                                      | `konga_database`                             |
 | DB_PG_SCHEMA       | If using postgres as a database, this is the schema that will be used.                                                     | -                                      | `public`                                     |
+| DB_IS_PG12_OR_NEWER| If `true` will set `isVersion12OrNewer: true` to sails-postgresql in order to work with Postgres12 or newer.               | true/false |                           | false                                        |
 | KONGA_LOG_LEVEL    | The logging level                                                                                                          | `silly`,`debug`,`info`,`warn`,`error`  | `debug` on dev environment & `warn` on prod. |
 | TOKEN_SECRET       | The secret that will be used to sign JWT tokens issued by Konga | - | - |
 | NO_AUTH            | Run Konga without Authentication                                                                                           | true/false                             | -                                         |

--- a/config/connections.js
+++ b/config/connections.js
@@ -83,7 +83,8 @@ module.exports.connections = {
     database: process.env.DB_DATABASE ||'konga_database',
     // schema: process.env.DB_PG_SCHEMA ||'public',
     poolSize: process.env.DB_POOLSIZE || 10,
-    ssl: process.env.DB_SSL ? true : false // If set, assume it's true
+    ssl: process.env.DB_SSL ? true : false, // If set, assume it's true,
+    isVersion12OrNewer: process.env.DB_IS_PG12_OR_NEWER || false 
   },
 
   /**

--- a/config/connections.js
+++ b/config/connections.js
@@ -83,7 +83,7 @@ module.exports.connections = {
     database: process.env.DB_DATABASE ||'konga_database',
     // schema: process.env.DB_PG_SCHEMA ||'public',
     poolSize: process.env.DB_POOLSIZE || 10,
-    ssl: process.env.DB_SSL ? true : false, // If set, assume it's true,
+    ssl: process.env.DB_SSL ? true : false, // If set, assume it's true
     isVersion12OrNewer: process.env.DB_IS_PG12_OR_NEWER || false 
   },
 


### PR DESCRIPTION
.env
```
PORT=1337
NODE_ENV=production
KONGA_HOOK_TIMEOUT=120000
DB_ADAPTER=postgres
DB_URI=postgresql://localhost:5432/konga
KONGA_LOG_LEVEL=warn
TOKEN_SECRET=some_secret_token
DB_IS_PG12_OR_NEWER=true
```

Tested on Postgres14.1
<img width="1680" alt="Screen Shot 2564-12-16 at 06 46 57" src="https://user-images.githubusercontent.com/724055/146282410-e1b0c147-2a55-4d5f-941e-ec046381a4ef.png">

